### PR TITLE
test: pin maturin@1.8.7 for now

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -44,7 +44,7 @@ jobs:
           echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
           
       - name: install maturin
-        run: cargo install cargo-binstall && cargo binstall maturin
+        run: cargo install cargo-binstall && cargo binstall maturin@1.8.7 # 1.9.0 currently has some issues, as it was just published and the bin is not distributed, and compilation fails
 
       - name: maturin develop
         run: maturin develop -m py/Cargo.toml --no-default-features -F tok


### PR DESCRIPTION
1.9.0 was just released, and apparently the binary is not fully propagated. And due to [1], compilation is tricky.

[1] https://github.com/PyO3/maturin/issues/2659