### PR TITLE
Add project description to PyPI page

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install maturin
         run: pip install maturin
       - name: maturin build
-        run: maturin build --release -m spnl/Cargo.toml --no-default-features -F run_py -F tok
+        run: maturin build --sdist --release -m spnl/Cargo.toml --no-default-features -F run_py,tok
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:

--- a/spnl/pyproject.toml
+++ b/spnl/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "maturin"
 [project]
 name = "spnl"
 requires-python = ">=3.8"
+readme = "../README.md"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Currently  [spnl PyPI page](https://pypi.org/project/spnl/) has no project description. This is due to the `pyproject.toml` not including the README.md section.
In addition to that README.md specified in `pyproject.toml` are not included in binary distributions (i.e: wheel builds) so a source distribution needs to be created as well.
In addition made a small refactor of the `--features` flag of `maturin build` according to the documentation.