### PR TITLE
feat: perform rag indexing prior to run rather than as-we-run

### DIFF
--- a/benchmarks/haystack/src/main.rs
+++ b/benchmarks/haystack/src/main.rs
@@ -189,7 +189,6 @@ async fn main() -> Result<(), SpnlError> {
             vecdb_uri: "".to_string(),
             vecdb_table: "".to_string(),
         },
-        Some(&indicatif::MultiProgress::new()),
     )
     .await?
     {

--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -17,7 +17,8 @@ pub struct Args {
     pub model: String,
 
     /// Embedding Model
-    #[arg(short, long, default_value = "ollama/mxbai-embed-large:335m")]
+    #[arg(short, long, default_value = "ollama/granite-embedding:30m")]
+    // mxbai-embed-large:335m
     pub embedding_model: String,
 
     /// Temperature

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<(), SpnlError> {
         ptree::write_tree(&program, ::std::io::stderr())?;
     }
 
-    let res = run(&program, &rp, None).await.map(|res| {
+    let res = run(&program, &rp).await.map(|res| {
         if !res.to_string().is_empty() {
             println!("{res}");
         }

--- a/spnl/src/python.rs
+++ b/spnl/src/python.rs
@@ -54,7 +54,6 @@ pub async fn execute(q: String) -> Result<ChatResponse, PyErr> {
             vecdb_table: "".into(),
             prepare: None,
         },
-        None,
     ));
 
     res.map(|res| ChatResponse {


### PR DESCRIPTION
This helps with display, so that we can have a single indicatif MultiProgress

Eventually, we may want to move this, as well as the retrieval, to `plan()`. This would give us a nice split between rag logic and execution logic. The `run()` would then be completely separate from any RAG logic. Eventually this might help us separate the planner and the executor even into two separate services, etc.