### PR TITLE
Publish README in PyPI

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
     
 jobs:
-  build_wheels:
+  build_wheels_and_sdist:
     runs-on: ${{ matrix.os }} 
     strategy:
       matrix:
@@ -32,14 +32,14 @@ jobs:
         run: pip install maturin
       - name: maturin build
         run: maturin build --sdist --release -m spnl/Cargo.toml --no-default-features -F run_py,tok
-      - name: Upload wheels
+      - name: Upload wheels and sdist
         uses: actions/upload-artifact@v4
         with:
           name: build-${{ matrix.os }}-${{matrix.python-version}}-${{ github.sha }}
-          path: target/wheels/*.whl
+          path: target/wheels/
 
   publish_to_pypi:
-    needs: build_wheels
+    needs: build_wheels_and_sdist
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Needed for trusted publishing
@@ -54,7 +54,7 @@ jobs:
         run: |
           find artifacts1
           mkdir artifacts
-          find artifacts1 -name '*.whl' -exec mv {} artifacts \; -print
+          find artifacts1 \( -name '*.whl' -o -name '*.tar.gz' \) -exec mv {} artifacts \; -print
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "spnl"
 requires-python = ">=3.8"
-readme = "../README.md"
+readme = "README.md"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,6 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
+
+[tool.maturin]
+features = ["run_py", "tok"]


### PR DESCRIPTION
Moved the pyproject.toml to the top level of the directory since maturin maturin doesn't allow for `..` in paths.

In addition now we publish both sdist and wheel to pypi.