### PR TITLE
fix: present rag matches in order of increasing matchiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,6 +6102,7 @@ dependencies = [
  "arrow-schema",
  "async-openai",
  "async-recursion",
+ "atoi",
  "derive_builder",
  "duct",
  "fs4 0.13.1",

--- a/cli/src/builtins/rag.rs
+++ b/cli/src/builtins/rag.rs
@@ -23,9 +23,10 @@ pub fn query(args: crate::args::Args) -> anyhow::Result<spnl::Query> {
     };
 
     let system_prompt = r#"
-Respond with either "UNANSWERABLE" or "ANSWERABLE" depending
-on whether or not the given documents are sufficient to answer the
-question. Include citation to documents used to service the question.
+Respond with either "UNANSWERABLE" or "ANSWERABLE" depending on
+whether or not the given documents are sufficient to answer the
+question and cite the Relevant
+Documents used to answer the question. Do not rely on your pre-trained knowledge. 
 "#;
 
     Ok(spnl::spnl!(

--- a/spnl/Cargo.toml
+++ b/spnl/Cargo.toml
@@ -50,3 +50,4 @@ moka = { version = "0.12.10", features = ["sync"], optional = true }
 reqwest = { version = "0.12.20", features = ["json"], optional = true }
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 thiserror = "2.0.14"
+atoi = "2.0.0"

--- a/spnl/src/run/with.rs
+++ b/spnl/src/run/with.rs
@@ -27,7 +27,15 @@ pub async fn retrieve(
 
     use std::time::Instant;
     let now = Instant::now();
-    let max_matches = 100; // Maximum number of relevant fragments to consider
+
+    // Maximum number of relevant fragments to consider
+    let max_matches: usize = atoi::atoi(
+        ::std::env::var("SPNL_RAG_MAX_MATCHES")
+            .as_deref()
+            .unwrap_or("100")
+            .as_bytes(),
+    )
+    .ok_or(anyhow::anyhow!("Invalid SPNL_RAG_MAX_MATCHES value"))?;
 
     let window_size = match content {
         Document::Text(_) => 1,
@@ -126,9 +134,11 @@ pub async fn retrieve(
     }
 
     let d = matching_docs
+        .into_iter()
+        .rev() // reverse so that we can present the most relevant closest to the query (at the end)
         .enumerate()
-        .map(|(idx, doc)| Query::User(format!("Relevant document {idx}: {doc}")))
-        .collect::<Vec<_>>();
+        .map(|(idx, doc)| Query::User(format!("Relevant Document {idx}: {doc}")))
+        .collect();
 
     if verbose {
         eprintln!("RAG time {:.2?} ms", now.elapsed().as_millis());


### PR DESCRIPTION
Also adds support for an env var to pass through max matches: SPNL_RAG_MAX_MATCHES

TODO: use clap to link this env var to a command line option's default value.