### PR TITLE
feat: first pass at raptor cross-indexing

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> Result<(), SpnlError> {
 
     let plan_options = PlanOptions {
         aug: AugmentOptionsBuilder::default()
+            .verbose(args.verbose)
             .max_aug(args.max_aug)
             .vecdb_uri(args.vecdb_uri.clone())
             .vecdb_table(

--- a/spnl/src/augment/embed.rs
+++ b/spnl/src/augment/embed.rs
@@ -2,6 +2,7 @@ use crate::Query;
 use crate::generate::backend::openai;
 
 pub enum EmbedData {
+    String(String),
     Query(Query),
     Vec(Vec<String>),
 }

--- a/spnl/src/augment/index/mod.rs
+++ b/spnl/src/augment/index/mod.rs
@@ -10,18 +10,23 @@ use crate::{
     augment::{AugmentOptions, Indexer},
 };
 
-fn extract_augments(query: &Query) -> Vec<Augment> {
-    match query {
-        Query::Generate(crate::Generate { input, .. }) => extract_augments(input),
-        Query::Plus(v) | Query::Cross(v) => v.iter().flat_map(extract_augments).collect(),
-        Query::Augment(a) => vec![a.clone()],
+fn extract_augments(query: &Query, enclosing_model: &Option<String>) -> Vec<(String, Augment)> {
+    match (query, enclosing_model) {
+        (Query::Generate(crate::Generate { model, input, .. }), _) => {
+            extract_augments(input, &Some(model.clone()))
+        }
+        (Query::Plus(v) | Query::Cross(v), _) => v
+            .iter()
+            .flat_map(|q| extract_augments(q, enclosing_model))
+            .collect(),
+        (Query::Augment(a), Some(enclosing_model)) => vec![(enclosing_model.clone(), a.clone())],
         _ => vec![],
     }
 }
 
 pub async fn index(query: &Query, options: &AugmentOptions) -> anyhow::Result<()> {
     let m = MultiProgress::new();
-    let augments = extract_augments(query);
+    let augments = extract_augments(query, &None);
 
     match options.indexer {
         Indexer::Raptor => raptor::index(&augments, options, &m).await,

--- a/spnl/src/augment/index/raptor.rs
+++ b/spnl/src/augment/index/raptor.rs
@@ -1,13 +1,156 @@
-use super::layer1::process_corpora;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use itertools::Itertools; // for .unique()
+
+use super::layer1::{Fragments, process_corpora};
+use crate::augment::storage;
+use crate::{
+    Augment, Query,
+    augment::{
+        AugmentOptions,
+        embed::{EmbedData, embed},
+    },
+    generate::generate,
+};
 
 /// Index using the RAPTOR algorithm https://github.com/parthsarthi03/raptor
 pub async fn index(
-    a: &[crate::Augment],
-    options: &crate::augment::AugmentOptions,
-    m: &indicatif::MultiProgress,
+    a: &[(String, Augment)], // (enclosing_model, Augment)
+    options: &AugmentOptions,
+    m: &MultiProgress,
 ) -> anyhow::Result<()> {
-    // first, index the documents
-    process_corpora(a, options, m).await?;
+    futures::future::try_join_all(
+        process_corpora(a, options, m) // this will generate one Fragments struct per corpus
+            .await?
+            .map(|f| cross_index(f, options, m)), // then iterate over each Fragments struct to "cross index" it
+    )
+    .await?;
 
+    Ok(())
+}
+
+/// "Cross index" the given `Fragments`, meaning, for each fragment in Fragments:
+/// 1. Look it up (in the vector database `db`) to find similar fragments.
+/// 2. Ask an LLM to summarize these related fragments.
+/// 3. Embed that summary
+/// 4. Insert summary+embedding into `db` to aid subsequent retrievals
+async fn cross_index(
+    Fragments {
+        embedding_model,
+        enclosing_model,
+        fragments,
+        filename,
+        table_name,
+        ..
+    }: Fragments,
+    options: &AugmentOptions,
+    m: &MultiProgress,
+) -> anyhow::Result<()> {
+    let db = storage::VecDB::connect(&options.vecdb_uri, table_name.as_str()).await?;
+    let pb = m.add(
+        ProgressBar::new(fragments.len() as u64)
+            .with_style(ProgressStyle::with_template(
+                "{msg} {wide_bar:.gray/green} {pos:>7}/{len:7} [{elapsed_precise}]",
+            )?)
+            .with_message(format!(
+                "Cross-indexing {}",
+                ::std::path::Path::new(&filename)
+                    .file_name()
+                    .ok_or(anyhow::anyhow!("Could not determine base name"))?
+                    .display()
+            )),
+    );
+    pb.inc(0); // to get it to show up right away
+
+    futures::future::try_join_all(fragments.into_iter().map(|f| {
+        cross_index_fragment(f, &embedding_model, &enclosing_model, &db, options, &pb, m)
+    }))
+    .await?;
+
+    Ok(())
+}
+
+async fn cross_index_fragment(
+    fragment: (String, Vec<f32>),
+    embedding_model: &String,
+    enclosing_model: &str,
+    db: &storage::VecDB,
+    options: &AugmentOptions,
+    pb: &ProgressBar,
+    m: &MultiProgress,
+) -> anyhow::Result<()> {
+    // Maximum number of relevant fragments to consider
+    let max_matches: usize = options.max_aug.unwrap_or(10);
+
+    // TODO, this shares logic with retrieve.rs
+    let input = db
+        .find_similar(fragment.1, max_matches)
+        .await?
+        .into_iter()
+        .filter_map(|record_batch| {
+            if let Some(files_array) = record_batch.column_by_name("filename")
+                && let Some(files) = files_array
+                    .as_any()
+                    .downcast_ref::<arrow_array::StringArray>()
+            {
+                // Here are the fragments that are near to the given fragment
+                Some(
+                    files
+                        .iter()
+                        .filter_map(|b| b.map(|b| b.to_string()))
+                        .collect::<Vec<_>>(),
+                )
+            } else {
+                None
+            }
+        })
+        .flatten()
+        .unique()
+        .map(|s| Query::User(format!("Detail Document: {s}")))
+        .chain([Query::User(format!("Main Document: {}", fragment.0))])
+        .collect::<Vec<_>>();
+
+    let num_fragments = input.len() - 1;
+    let original_length = input
+        .iter()
+        .map(|q| match q {
+            Query::User(s) => s.len(),
+            _ => 0,
+        })
+        .sum::<usize>();
+
+    let max_tokens = &Some(100); // TODO
+    let temp = &Some(0.2);
+
+    let summary = match generate(
+        enclosing_model,
+        &Query::Cross(vec![
+            Query::System("Your job is to extract term definitions from Detail Documents in order to create very short summaries that substantiate the Main Document".into()),
+            Query::Plus(input),
+        ]),
+        max_tokens,
+        temp,
+        Some(m),
+        false,
+    )
+        .await? {
+            Query::User(s) => s,
+            _ => "".into(),
+        };
+
+    if options.verbose {
+        let summarized_length = summary.len();
+        eprintln!(
+            "Raptor summary of {num_fragments} fragments {original_length} -> {summarized_length}: '{summary}'"
+        );
+    }
+
+    // Now embed and then insert the summary into the vector db (TODO?
+    // batch these up?)
+    let vector_embedding = embed(embedding_model, EmbedData::String(summary.clone()))
+        .await?
+        .collect();
+    db.add_vector(&[summary], vector_embedding, 1024).await?;
+
+    pb.inc(1);
     Ok(())
 }

--- a/spnl/src/augment/index/simple_embed_retrieve.rs
+++ b/spnl/src/augment/index/simple_embed_retrieve.rs
@@ -2,9 +2,10 @@ use super::layer1::process_corpora;
 
 /// Index by embedding only
 pub async fn index(
-    a: &[crate::Augment],
+    a: &[(String, crate::Augment)], // (enclosing_model, Augment)
     options: &crate::augment::AugmentOptions,
     m: &indicatif::MultiProgress,
 ) -> anyhow::Result<()> {
-    process_corpora(a, options, m).await
+    let _ = process_corpora(a, options, m).await?;
+    Ok(())
 }

--- a/spnl/src/augment/options.rs
+++ b/spnl/src/augment/options.rs
@@ -23,4 +23,8 @@ pub struct AugmentOptions {
     /// Scheme to use for indexing the corpus
     #[builder(default)]
     pub indexer: Indexer,
+
+    /// Scheme to use for indexing the corpus
+    #[builder(default)]
+    pub verbose: bool,
 }


### PR DESCRIPTION
The implemntation works as follows:

1. first, do "normal" indexing where we fragment the corpus, embed each fragment, and then insert these vector embeddings into a vector database
2. "Cross index" the given `Fragments`, meaning, for each fragment in Fragments:
    1. Look it up (in the vector database `db`) to find similar fragments.
    2. Ask an LLM to summarize these related fragments.
    3. Embed that summary
    4. Insert summary+embedding into `db` to aid subsequent retrievals

Here, we differ from the [raptor paper](https://arxiv.org/abs/2401.18059) at step the "Look it up to find similar fragments" step. The paper uses a distinct clustering algorithm, whereas we rely on the vector database to do this clustering for us. We shall see if that is effective...