### PR TITLE
fix: remove a few uses of `collect()` in the vectordb storage layer

### DIFF
--- a/spnl/src/augment/index/layer1.rs
+++ b/spnl/src/augment/index/layer1.rs
@@ -141,9 +141,7 @@ async fn process_document(
             fragments
                 .iter()
                 .enumerate()
-                .map(|(idx, fragment)| format!("@base-{}-{idx}: {fragment}", file_base_name))
-                .collect::<Vec<_>>()
-                .as_slice(),
+                .map(|(idx, fragment)| format!("@base-{}-{idx}: {fragment}", file_base_name)),
             vector_embeddings.clone(),
             1024,
         )

--- a/spnl/src/augment/index/raptor.rs
+++ b/spnl/src/augment/index/raptor.rs
@@ -167,11 +167,9 @@ async fn cross_index_fragment(
 
     // Now embed and then insert the summary into the vector db (TODO?
     // batch these up?)
-    let vector_embedding = embed(embedding_model, EmbedData::String(summary.clone()))
-        .await?
-        .collect();
+    let vector_embedding = embed(embedding_model, EmbedData::String(summary.clone())).await?;
     db.add_vector(
-        &[format!("@raptor-{file_base_name}-{idx}: {summary}")],
+        [format!("@raptor-{file_base_name}-{idx}: {summary}")],
         vector_embedding,
         1024,
     )

--- a/spnl/src/augment/storage.rs
+++ b/spnl/src/augment/storage.rs
@@ -74,12 +74,16 @@ impl VecDB {
         ]))
     }
 
-    pub async fn add_vector(
+    pub async fn add_vector<I1, I2>(
         &self,
-        filenames: &[String],
-        vectors: Vec<Vec<f32>>,
+        filenames: I1,
+        vectors: I2,
         vec_dim: i32,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<()>
+    where
+        I1: IntoIterator<Item = String>,
+        I2: IntoIterator<Item = Vec<f32>>,
+    {
         let schema = self.default_table.schema().await?;
         let key_array = StringArray::from_iter_values(filenames);
         let vectors_array = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(


### PR DESCRIPTION
Part of #243