### PR TITLE
feat: introduce Message enum, and pull A,S,U out of Query and into it

### DIFF
--- a/benchmarks/haystack/src/main.rs
+++ b/benchmarks/haystack/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use petname::Generator; // Trait needs to be in scope for `iter`.
-use spnl::{ExecuteOptions, Query, SpnlError, execute, spnl};
+use spnl::{ExecuteOptions, Message::User, Query, SpnlError, execute, spnl};
 
 type GeneratedNames = Vec<String>;
 #[derive(serde::Deserialize)]
@@ -179,7 +179,7 @@ async fn main() -> Result<(), SpnlError> {
     }
 
     match execute(&query, &ExecuteOptions { prepare: None }).await? {
-        Query::User(ss) => {
+        Query::Message(User(ss)) => {
             // oof, be gracious here. sometimes the model wraps the
             // requested json array with markdown even though we asked
             // it not to

--- a/spnl/src/execute.rs
+++ b/spnl/src/execute.rs
@@ -1,4 +1,4 @@
-use crate::{Generate, Query};
+use crate::{Generate, Message::*, Query};
 use indicatif::MultiProgress;
 
 pub struct ExecuteOptions {
@@ -44,7 +44,7 @@ async fn run_subtree(query: &Query, rp: &ExecuteOptions, m: Option<&MultiProgres
     crate::pull::pull_if_needed(query).await?;
 
     match query {
-        Query::Assistant(_) | Query::User(_) | Query::System(_) => Ok(query.clone()),
+        Query::Message(_) => Ok(query.clone()),
 
         Query::Cross(u) => cross(u, rp, m).await,
         Query::Plus(u) => plus(u, rp).await,
@@ -69,7 +69,7 @@ async fn run_subtree(query: &Query, rp: &ExecuteOptions, m: Option<&MultiProgres
         #[cfg(feature = "cli_support")]
         Query::Print(m) => {
             println!("{m}");
-            Ok(Query::User("".into()))
+            Ok(Query::Message(User("".into())))
         }
         #[cfg(feature = "cli_support")]
         Query::Ask(message) => {
@@ -87,7 +87,7 @@ async fn run_subtree(query: &Query, rp: &ExecuteOptions, m: Option<&MultiProgres
                 Err(err) => panic!("{}", err), // TODO this only works in a CLI
             };
             rl.append_history("history.txt").unwrap();
-            Ok(Query::User(prompt))
+            Ok(Query::Message(User(prompt)))
         }
 
         // TODO: should not happen; we need to improve the typing of runnable queries
@@ -104,7 +104,7 @@ mod tests {
     #[tokio::test]
     async fn it_works() -> Result<(), SpnlError> {
         let result = execute(&"hello".into(), &ExecuteOptions { prepare: None }).await?;
-        assert_eq!(result, Query::User("hello".to_string()));
+        assert_eq!(result, Query::Message(User("hello".to_string())));
         Ok(())
     }
 }

--- a/spnl/src/generate/backend/spnl.rs
+++ b/spnl/src/generate/backend/spnl.rs
@@ -1,7 +1,7 @@
 use indicatif::MultiProgress;
 use tokio::io::{AsyncWriteExt, stdout};
 
-use crate::{Generate, Query, SpnlResult, to_string};
+use crate::{Generate, Message::Assistant, Query, SpnlResult, to_string};
 
 #[derive(serde::Deserialize)]
 struct Message {
@@ -62,5 +62,5 @@ pub async fn generate(
         stdout.write_all(b"\n").await?;
     }
 
-    Ok(Query::Assistant(response_string))
+    Ok(Query::Message(Assistant(response_string)))
 }

--- a/spnl/src/plan.rs
+++ b/spnl/src/plan.rs
@@ -35,7 +35,7 @@ async fn plan_iter(query: &Query, po: &PlanOptions) -> anyhow::Result<Vec<Query>
         Query::Augment(a) => Ok(vec![Query::Plus(
             crate::augment::retrieve(&a.embedding_model, &a.body, &a.doc, &po.aug)
                 .await?
-                .map(Query::User)
+                .map(|s| Query::Message(crate::Message::User(s)))
                 .collect(),
         )]),
 


### PR DESCRIPTION
BREAKING CHANGE: Query::User(s) is now Query::Message(Message::User(s)), same for Assistant and System

This does not affect the serialized forms (Query::Message is specified to be untagged), only the Rust code that operates on them.

This should clean up code that operates in particular on messages. Without this change, we could only pass in a full Query because messages were inlined into the Query enum.