### PR TITLE
fix: playground support for print, seq, par

### DIFF
--- a/spnl/Cargo.toml
+++ b/spnl/Cargo.toml
@@ -10,6 +10,7 @@ description = "A Span Query is a declarative way to specify which portions of a 
 [features]
 default = ["cli_support","lisp","run","ollama","openai","gemini","pull","yaml"]
 cli_support = ["dep:ptree","dep:rustyline"]
+print = []
 lisp = ["dep:serde-lexpr"]
 ollama = ["openai"]
 openai = ["dep:async-openai","dep:tokio","dep:tokio-stream"]

--- a/spnl/src/execute.rs
+++ b/spnl/src/execute.rs
@@ -85,7 +85,7 @@ async fn run_subtree(query: &Query, rp: &ExecuteOptions, m: Option<&MultiProgres
             .await
         }
 
-        #[cfg(feature = "cli_support")]
+        #[cfg(feature = "print")]
         Query::Print(m) => {
             println!("{m}");
             Ok(Query::Message(User("".into())))

--- a/spnl/src/query.rs
+++ b/spnl/src/query.rs
@@ -110,7 +110,7 @@ pub enum Query {
     Ask(String),
 
     /// Print a helpful message to the console
-    #[cfg(feature = "cli_support")]
+    #[cfg(feature = "print")]
     Print(String),
 
     /// Some sort of message

--- a/web/playground/src/Query.ts
+++ b/web/playground/src/Query.ts
@@ -5,6 +5,8 @@ export type User = { user: string }
 export type System = { system: string }
 export type Assistant = { assistant: string }
 export type Print = { print: string }
+export type Seq = { seq: Query[] }
+export type Par = { par: Query[] }
 export type Plus = { plus: Query[] }
 export type Cross = { cross: Query[] }
 export type Repeat = { repeat: { n: number; query: Query } }
@@ -16,6 +18,8 @@ export type Query =
   | User
   | System
   | Assistant
+  | Seq
+  | Par
   | Plus
   | Cross
   | Repeat

--- a/web/playground/src/Topology.tsx
+++ b/web/playground/src/Topology.tsx
@@ -36,6 +36,20 @@ function graphify(unit: import("./Query").Query, id = "root"): Data[] {
         .fill(0)
         .flatMap((_, idx) => graphify(repeat.query, id + "." + idx)),
     )
+    .with({ seq: P.array() }, ({ seq }) => [
+      node(
+        id,
+        "..",
+        seq.flatMap((child, idx) => graphify(child, id + ".X+" + idx)),
+      ),
+    ])
+    .with({ par: P.array() }, ({ par }) => [
+      node(
+        id,
+        "||",
+        par.flatMap((child, idx) => graphify(child, id + ".X+" + idx)),
+      ),
+    ])
     .with({ cross: P.array() }, ({ cross }) => [
       node(
         id,

--- a/web/playground/src/run.ts
+++ b/web/playground/src/run.ts
@@ -108,6 +108,13 @@ ${x.system
       /* will be expanded by the planner */
       return x
     })
+    .with({ seq: P.array() }, async ({ seq }) => {
+      const results = []
+      for (const c of seq) {
+        results.push(await run(c, props, inPlusOrCross))
+      }
+      return { seq: results }
+    })
     .with({ cross: P.array() }, async ({ cross }) => {
       const results = []
       for (const c of cross) {
@@ -124,6 +131,21 @@ ${x.system
       return {
         plus: await Promise.all(
           plus.map((u) => {
+            const idx = isGenerate(u) ? genIdx++ : -1
+            return run(u, props, idx)
+          }),
+        ),
+      }
+    })
+    .with({ par: P.array() }, async ({ par }) => {
+      const gens = par.filter(isGenerate)
+      if (gens.length > 0) {
+        props.setProgressDoPar(() => [] as InitProgress[])
+      }
+      let genIdx = 0
+      return {
+        par: await Promise.all(
+          par.map((u) => {
             const idx = isGenerate(u) ? genIdx++ : -1
             return run(u, props, idx)
           }),

--- a/web/wasm/Cargo.toml
+++ b/web/wasm/Cargo.toml
@@ -8,6 +8,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde_json = "1.0.140"
-spnl = { version = ">=0.1.0", path = "../../spnl", default-features = false, features = ["run","yaml"] }
+spnl = { version = ">=0.1.0", path = "../../spnl", default-features = false, features = ["run","yaml","print"] }
 wasm-bindgen = "0.2.100"
 wasm-bindgen-futures = "0.4.50"


### PR DESCRIPTION
This adds a `print` feature. Previously it was included in the `cli_support` feature.